### PR TITLE
Do Not Add Distribution Default OpenStack Release

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -10,3 +10,4 @@
    repo: 'deb http://ubuntu-cloud.archive.canonical.com/ubuntu {{ ansible_distribution_release }}-updates/{{ openstack_version }} main'
    state: present
    update_cache: yes
+  when: openstack_repo_ubuntu_builtin_releases.{{ ansible_distribution_release }} != '{{ openstack_version }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,6 @@
 ---
 # vars file for rdo
+
+openstack_repo_ubuntu_builtin_releases:
+  trusty: "icehouse"
+  xenial: "mitaka"


### PR DESCRIPTION
Ubuntu LTS versions comes with a built-in OpenStack packages, and there
are no corresponding Cloud Archive repository, for example Xenial
includes Mitaka, and there are no Mitaka repository for Xenial in Cloud
Archive.  Therefore, only add Cloud Archive if necessary.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
